### PR TITLE
Specifying that it requires PHP is redundant as the name of the script is

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -1,6 +1,5 @@
 # PHP MongoDB Admin
 
-A PHP MongoDB Admin interface that will requires PHP and will run
-in your web browser.
+A MongoDB Admin interface that runs in your web browser.
 
 Open mongodbadmin.php in your browser and have a look!


### PR DESCRIPTION
Specifying that it requires PHP is redundant as the name of the script is PHP MongoDB Admin.
