### PR TITLE
Cast custom id to INT  type if it's numeric 

### DIFF
--- a/mongodbadmin.php
+++ b/mongodbadmin.php
@@ -282,7 +282,11 @@ try {
     $collection = $mongo->selectDB($_REQUEST['db'])->selectCollection($_REQUEST['collection']);
 
     if (isset($_REQUEST['custom_id'])) {
-      $collection->remove(array('_id' => $_REQUEST['delete_document']));
+        $id = $_REQUEST['delete_document'];
+      if (is_numeric($id)) {
+        $id = (int) $id;
+      }
+      $collection->remove(array('_id' => $id));
     } else {
       $collection->remove(array('_id' => new MongoId($_REQUEST['delete_document'])));
     }


### PR DESCRIPTION
I guess in most cases if custom ID is numeric then it's better to cast it to INT type otherwise MongoDB can't find a document. 
