### PR TITLE
bugfix custom auto incremented numeric id was not found

### DIFF
--- a/mongodbadmin.php
+++ b/mongodbadmin.php
@@ -202,6 +202,9 @@ function findMongoDbDocument($id, $db, $collection, $forceCustomId = false)
   $collection = $mongo->selectDB($db)->selectCollection($collection);
 
   if (isset($_REQUEST['custom_id']) || $forceCustomId) {
+    if(is_numeric($id))
+      $id = (int) $id;
+
     $document =$collection->findOne(array('_id' => $id));
   } else {
     $document = $collection->findOne(array('_id' => new MongoId($id)));
@@ -440,7 +443,7 @@ try {
       border-bottom: 1px solid #ccc;
     }
     table tbody tr:hover {
-    	background-color: #eee;
+       background-color: #eee;
     }
     .save_button {
       -moz-border-radius: 10px;


### PR DESCRIPTION
mongoadmin was passing custom id as string to collection->findOne method, but my custom id is numeric, this prevented the record to be found.
