### PR TITLE
Let's make default sort by _id ASC

### DIFF
--- a/mongodbadmin.php
+++ b/mongodbadmin.php
@@ -614,7 +614,8 @@ try {
         ->selectCollection($_REQUEST['collection'])
         ->find()
         ->limit($limit)
-        ->skip($skip);
+        ->skip($skip)
+        ->sort(array('_id' => 1));
     }
 
     $total = $cursor->count();


### PR DESCRIPTION
It's hard to orientate among documents without sorting at all. So let's make default sort at least.
