### PR TITLE
No Cross Site Scripting

### DIFF
--- a/mongodbadmin.php
+++ b/mongodbadmin.php
@@ -167,8 +167,8 @@ function prepareValueForMongoDB($value)
 /**
  * Do not execute Javascript like <script>alert("XSS Attack");</script>
  *
- * @param string $document
- * @return string $preview
+ * @param string $value
+ * @return string $prepared
  */
 
 function secureOutput($value)


### PR DESCRIPTION
If you add a entry like 
[field] = "[[script]]alert('XSS Attack');[[/script]]" to a document, the Javascript is executed. This change should fix the issue.
Edit: Replace [[ and ]] with angle brackets, Github removed them from the description.
